### PR TITLE
name of parent directory duplicates when resuming the training

### DIFF
--- a/ckpt_manager.py
+++ b/ckpt_manager.py
@@ -39,7 +39,7 @@ class CKPT_Manager:
         else:
             if name is not None:
                 file_name = name
-                file_path = os.path.join(self.root_dir_ckpt, file_name)
+                file_path = file_name
             if abs_name is not None:
                 file_name = os.path.basename(abs_name)
                 file_path = abs_name


### PR DESCRIPTION
The parent directory is joined already in line 69, but it is joined again in line 42.
So, I revised it.